### PR TITLE
Allow clients to instantiate DKAsset

### DIFF
--- a/DKImageManager/Data/Model/DKAsset.swift
+++ b/DKImageManager/Data/Model/DKAsset.swift
@@ -32,7 +32,7 @@ public class DKAsset: NSObject {
 	
 	public private(set) var originalAsset: PHAsset?
 		
-	init(originalAsset: PHAsset) {
+	public init(originalAsset: PHAsset) {
 		super.init()
 		
 		self.originalAsset = originalAsset


### PR DESCRIPTION
This allows assets to be saved using the localIdentifier string, then reloaded later into the picker.
